### PR TITLE
feat(queue): implement ctb_QueueArray — ring-buffer-backed queue (#8)

### DIFF
--- a/src/ctb_QueueArray.c
+++ b/src/ctb_QueueArray.c
@@ -1,0 +1,97 @@
+#include <string.h>
+
+#include "ctb.h"
+#include "ctb_QueueArray.h"
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+ctb_QueueArray_t * ctb_QueueArray_init(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    ctb_assert(self->array.items);
+    ctb_assert(self->array.itemSize > 0);
+    ctb_assert(self->array.capacity > 0);
+    ctb_Array_init(&self->array);
+    self->head   = 0;
+    self->tail   = 0;
+    self->length = 0;
+    return self;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+bool ctb_QueueArray_enqueue(
+    ctb_QueueArray_t * const self,
+    void const * const       value
+) {
+    ctb_assert(self);
+    ctb_assert(value);
+    if (self->length >= self->array.capacity) {
+        return false;
+    }
+    void * const dest =
+        (char *)self->array.items + (self->tail * self->array.itemSize);
+    memcpy(dest, value, self->array.itemSize);
+    self->tail = (self->tail + (size_t)1) % self->array.capacity;
+    self->length++;
+    return true;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void * ctb_QueueArray_dequeue(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    if (self->length == 0) {
+        return NULL;
+    }
+    void * const slot =
+        (char *)self->array.items + (self->head * self->array.itemSize);
+    self->head = (self->head + (size_t)1) % self->array.capacity;
+    self->length--;
+    return slot;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void * ctb_QueueArray_peek(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    if (self->length == 0) {
+        return NULL;
+    }
+    return (char *)self->array.items + (self->head * self->array.itemSize);
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+bool ctb_QueueArray_isEmpty(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->length == 0;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+size_t ctb_QueueArray_getLength(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->length;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+size_t ctb_QueueArray_getCapacity(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->array.capacity;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void ctb_QueueArray_clear(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    self->head   = 0;
+    self->tail   = 0;
+    self->length = 0;
+}

--- a/src/ctb_QueueArray.h
+++ b/src/ctb_QueueArray.h
@@ -1,0 +1,130 @@
+/**
+ * @file
+ */
+#ifndef CTB_QUEUE_ARRAY_H
+#define CTB_QUEUE_ARRAY_H
+#include <stdbool.h>
+#include <stddef.h>
+/**
+ * @ingroup ctb
+ * @defgroup ctb_QueueArray ctb_QueueArray
+ * @{
+ */
+
+/**
+ * @brief QueueArray type
+ */
+typedef struct ctb_QueueArray ctb_QueueArray_t;
+
+#include "ctb.h"
+#include "ctb_Array.h"
+
+/**
+ * @brief QueueArray data structure backed by a ring buffer
+ */
+struct ctb_QueueArray {
+    ctb_Array_t array;  /**< Underlying array storage */
+    size_t      head;   /**< Index of the front element */
+    size_t      tail;   /**< Index of the next free slot */
+    size_t      length; /**< Number of elements in the queue */
+};
+
+/**
+ * @brief Helper macro to initialize a QueueArray from a raw array
+ *
+ * @param arr The raw array to initialize the QueueArray with
+ * @return Pointer to a compound literal ctb_QueueArray_t
+ */
+#define ctb_QueueArray(                    \
+    arr                                    \
+)                                          \
+    (&(ctb_QueueArray_t){                  \
+        .array  = *(ctb_Array(arr)),       \
+        .head   = 0,                       \
+        .tail   = 0,                       \
+        .length = 0,                       \
+    })
+
+/**
+ * @brief Initializes a QueueArray
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the initialized QueueArray
+ */
+ctb_QueueArray_t * ctb_QueueArray_init(
+    ctb_QueueArray_t * const self
+);
+
+/**
+ * @brief Enqueues a value into the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @param value Pointer to the value to enqueue
+ * @return True if the value was enqueued, false if the queue is full
+ */
+bool ctb_QueueArray_enqueue(
+    ctb_QueueArray_t * const self,
+    void const * const       value
+);
+
+/**
+ * @brief Dequeues a value from the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the dequeued value, or NULL if the queue is empty
+ */
+void * ctb_QueueArray_dequeue(
+    ctb_QueueArray_t * const self
+);
+
+/**
+ * @brief Peeks at the front value without removing it
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the front value, or NULL if the queue is empty
+ */
+void * ctb_QueueArray_peek(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Checks if the queue is empty
+ *
+ * @param self Pointer to a QueueArray
+ * @return True if the queue is empty, false otherwise
+ */
+bool ctb_QueueArray_isEmpty(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Gets the number of elements in the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @return Number of elements in the queue
+ */
+size_t ctb_QueueArray_getLength(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Gets the capacity of the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @return Capacity of the queue
+ */
+size_t ctb_QueueArray_getCapacity(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Clears all elements from the queue
+ *
+ * @param self Pointer to a QueueArray
+ */
+void ctb_QueueArray_clear(
+    ctb_QueueArray_t * const self
+);
+
+/** @} */
+#endif // CTB_QUEUE_ARRAY_H

--- a/test/test_ctb_QueueArray.c
+++ b/test/test_ctb_QueueArray.c
@@ -1,0 +1,149 @@
+#include "unity.h"
+
+#include "ctb_QueueArray.h"
+#include "ctb_Array.h"
+#include "ctb_ArrayIterator.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_ctb_QueueArray_init_should_initialize_queue(void) {
+    int data[5];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_UINT32(0, ctb_QueueArray_getLength(queue));
+    TEST_ASSERT_EQUAL_UINT32(5, ctb_QueueArray_getCapacity(queue));
+    TEST_ASSERT_NULL(ctb_QueueArray_peek(queue));
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_init_macro_should_initialize_queue(void) {
+    int data[3];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_UINT32(3, ctb_QueueArray_getCapacity(queue));
+}
+
+void test_ctb_QueueArray_enqueue_should_add_value_to_queue(void) {
+    int data[5];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int val = 42;
+    TEST_ASSERT_TRUE(ctb_QueueArray_enqueue(queue, &val));
+    TEST_ASSERT_FALSE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_UINT32(1, ctb_QueueArray_getLength(queue));
+
+    int * front = (int *)ctb_QueueArray_peek(queue);
+    TEST_ASSERT_NOT_NULL(front);
+    TEST_ASSERT_EQUAL_INT(42, *front);
+}
+
+void test_ctb_QueueArray_enqueue_dequeue_should_respect_FIFO_order(void) {
+    int data[5];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int v1 = 10, v2 = 20, v3 = 30;
+    ctb_QueueArray_enqueue(queue, &v1);
+    ctb_QueueArray_enqueue(queue, &v2);
+    ctb_QueueArray_enqueue(queue, &v3);
+    TEST_ASSERT_EQUAL_UINT32(3, ctb_QueueArray_getLength(queue));
+
+    int * val = (int *)ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_NOT_NULL(val);
+    TEST_ASSERT_EQUAL_INT(10, *val);
+    TEST_ASSERT_EQUAL_UINT32(2, ctb_QueueArray_getLength(queue));
+
+    val = (int *)ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_EQUAL_INT(20, *val);
+    TEST_ASSERT_EQUAL_UINT32(1, ctb_QueueArray_getLength(queue));
+
+    val = (int *)ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_EQUAL_INT(30, *val);
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_enqueue_should_fail_when_full(void) {
+    int data[2];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int v1 = 1, v2 = 2, v3 = 3;
+    TEST_ASSERT_TRUE(ctb_QueueArray_enqueue(queue, &v1));
+    TEST_ASSERT_TRUE(ctb_QueueArray_enqueue(queue, &v2));
+    TEST_ASSERT_FALSE(ctb_QueueArray_enqueue(queue, &v3));
+    TEST_ASSERT_EQUAL_UINT32(2, ctb_QueueArray_getLength(queue));
+}
+
+void test_ctb_QueueArray_peek_should_return_front_without_removing(void) {
+    int data[5];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int v1 = 100, v2 = 200;
+    ctb_QueueArray_enqueue(queue, &v1);
+    ctb_QueueArray_enqueue(queue, &v2);
+
+    int * val = (int *)ctb_QueueArray_peek(queue);
+    TEST_ASSERT_EQUAL_INT(100, *val);
+    TEST_ASSERT_EQUAL_UINT32(2, ctb_QueueArray_getLength(queue));
+}
+
+void test_ctb_QueueArray_clear_should_empty_queue(void) {
+    int data[5];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int v1 = 10, v2 = 20;
+    ctb_QueueArray_enqueue(queue, &v1);
+    ctb_QueueArray_enqueue(queue, &v2);
+
+    ctb_QueueArray_clear(queue);
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_UINT32(0, ctb_QueueArray_getLength(queue));
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_wrap_around_should_maintain_FIFO_order(void) {
+    int data[3];
+    ctb_QueueArray_t * queue = ctb_QueueArray(data);
+    ctb_QueueArray_init(queue);
+
+    int v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5;
+
+    ctb_QueueArray_enqueue(queue, &v1);
+    ctb_QueueArray_enqueue(queue, &v2);
+    ctb_QueueArray_enqueue(queue, &v3);
+    TEST_ASSERT_EQUAL_UINT32(3, ctb_QueueArray_getLength(queue));
+
+    TEST_ASSERT_EQUAL_INT(1, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(2, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_UINT32(1, ctb_QueueArray_getLength(queue));
+
+    ctb_QueueArray_enqueue(queue, &v4);
+    ctb_QueueArray_enqueue(queue, &v5);
+    TEST_ASSERT_EQUAL_UINT32(3, ctb_QueueArray_getLength(queue));
+
+    TEST_ASSERT_EQUAL_INT(3, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(4, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(5, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+}
+
+void test_ctb_QueueArray_multiple_types(void) {
+    char cdata[3];
+    ctb_QueueArray_t * cqueue = ctb_QueueArray(cdata);
+    ctb_QueueArray_init(cqueue);
+    char ca = 'a', cb = 'b';
+    ctb_QueueArray_enqueue(cqueue, &ca);
+    ctb_QueueArray_enqueue(cqueue, &cb);
+    TEST_ASSERT_EQUAL_INT('a', *(char *)ctb_QueueArray_dequeue(cqueue));
+    TEST_ASSERT_EQUAL_INT('b', *(char *)ctb_QueueArray_dequeue(cqueue));
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(cqueue));
+}


### PR DESCRIPTION
Automated Agent Resolution for #8.

### Changes
- Implement ctb_QueueArray with ring buffer backing over user-provided array
- Init macro, enqueue/dequeue/peek/isEmpty/getLength/getCapacity/clear
- Wrap-around support for FIFO order across capacity boundaries
- Comprehensive unit tests covering all edge cases
- All 80 ceedling tests passing cleanly