### PR TITLE
feat(queuearray): add ring-buffer-backed queue data structure

### DIFF
--- a/src/ctb_QueueArray.c
+++ b/src/ctb_QueueArray.c
@@ -1,0 +1,90 @@
+#include <string.h>
+
+#include "ctb.h"
+#include "ctb_QueueArray.h"
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+ctb_QueueArray_t * ctb_QueueArray_init(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    ctb_assert(self->array.items);
+    ctb_assert(self->array.itemSize > 0);
+    ctb_assert(self->array.capacity > 0);
+    return self;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+bool ctb_QueueArray_isEmpty(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->length == 0;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+size_t ctb_QueueArray_getLength(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->length;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+size_t ctb_QueueArray_getCapacity(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    return self->array.capacity;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void ctb_QueueArray_enqueue(
+    ctb_QueueArray_t * const self,
+    void const * const       value
+) {
+    ctb_assert(self);
+    ctb_assert(value);
+    if (self->length >= self->array.capacity) {
+        return;
+    }
+    void * const dest = (char *)self->array.items + (self->tail * self->array.itemSize);
+    memcpy(dest, value, self->array.itemSize);
+    self->tail = (self->tail + 1) % self->array.capacity;
+    self->length++;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void * ctb_QueueArray_dequeue(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    if (self->length == 0) {
+        return NULL;
+    }
+    void * const item = (char *)self->array.items + (self->head * self->array.itemSize);
+    self->head = (self->head + 1) % self->array.capacity;
+    self->length--;
+    return item;
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void * ctb_QueueArray_peek(
+    ctb_QueueArray_t const * const self
+) {
+    ctb_assert(self);
+    if (self->length == 0) {
+        return NULL;
+    }
+    return (char *)self->array.items + (self->head * self->array.itemSize);
+}
+
+// cppcheck-suppress [staticFunction, unusedFunction] - API function
+void ctb_QueueArray_clear(
+    ctb_QueueArray_t * const self
+) {
+    ctb_assert(self);
+    self->head   = 0;
+    self->tail   = 0;
+    self->length = 0;
+}

--- a/src/ctb_QueueArray.h
+++ b/src/ctb_QueueArray.h
@@ -1,0 +1,128 @@
+/**
+ * @file
+ */
+#ifndef CTB_QUEUE_ARRAY_H
+#define CTB_QUEUE_ARRAY_H
+#include <stdbool.h>
+#include <stddef.h>
+/**
+ * @ingroup ctb
+ * @defgroup ctb_QueueArray ctb_QueueArray
+ * @{
+ */
+
+/**
+ * @brief QueueArray type
+ */
+typedef struct ctb_QueueArray ctb_QueueArray_t;
+
+#include "ctb_Array.h"
+
+/**
+ * @brief QueueArray data structure backed by a ring buffer
+ */
+struct ctb_QueueArray {
+    ctb_Array_t array;  /**< Underlying array storage */
+    size_t      head;   /**< Index of the front element */
+    size_t      tail;   /**< Index where the next element will be inserted */
+    size_t      length; /**< Current number of elements */
+};
+
+/**
+ * @brief Helper macro to initialize a QueueArray from a raw array
+ *
+ * @param arr The raw array to initialize the QueueArray with
+ * @return Pointer to a compound literal ctb_QueueArray_t
+ */
+#define ctb_QueueArray(        \
+    arr                        \
+)                              \
+    (&(ctb_QueueArray_t){      \
+        .array  = *(ctb_Array(arr)), \
+        .head   = 0,           \
+        .tail   = 0,           \
+        .length = 0,           \
+    })
+
+/**
+ * @brief Initializes a QueueArray
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the initialized QueueArray
+ */
+ctb_QueueArray_t * ctb_QueueArray_init(
+    ctb_QueueArray_t * const self
+);
+
+/**
+ * @brief Checks if the QueueArray is empty
+ *
+ * @param self Pointer to a QueueArray
+ * @return True if the QueueArray is empty, false otherwise
+ */
+bool ctb_QueueArray_isEmpty(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Gets the number of elements in the QueueArray
+ *
+ * @param self Pointer to a QueueArray
+ * @return Number of elements in the QueueArray
+ */
+size_t ctb_QueueArray_getLength(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Gets the capacity of the QueueArray
+ *
+ * @param self Pointer to a QueueArray
+ * @return Maximum number of elements the QueueArray can hold
+ */
+size_t ctb_QueueArray_getCapacity(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Adds an element to the end of the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @param value Pointer to the value to copy into the queue
+ */
+void ctb_QueueArray_enqueue(
+    ctb_QueueArray_t * const self,
+    void const * const       value
+);
+
+/**
+ * @brief Removes and returns the front element from the queue
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the removed front element, or NULL if the queue is empty
+ */
+void * ctb_QueueArray_dequeue(
+    ctb_QueueArray_t * const self
+);
+
+/**
+ * @brief Returns the front element without removing it
+ *
+ * @param self Pointer to a QueueArray
+ * @return Pointer to the front element, or NULL if the queue is empty
+ */
+void * ctb_QueueArray_peek(
+    ctb_QueueArray_t const * const self
+);
+
+/**
+ * @brief Clears all elements from the queue
+ *
+ * @param self Pointer to a QueueArray
+ */
+void ctb_QueueArray_clear(
+    ctb_QueueArray_t * const self
+);
+
+/** @} */
+#endif // CTB_QUEUE_ARRAY_H

--- a/test/test_ctb_QueueArray.c
+++ b/test/test_ctb_QueueArray.c
@@ -1,0 +1,163 @@
+#include "unity.h"
+
+#include "ctb_QueueArray.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_ctb_QueueArray_init_should_initialize_queue(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 5)));
+
+    TEST_ASSERT_NOT_NULL(queue);
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_INT(0, ctb_QueueArray_getLength(queue));
+    TEST_ASSERT_EQUAL_INT(5, ctb_QueueArray_getCapacity(queue));
+}
+
+void test_ctb_QueueArray_enqueue_should_add_elements(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val = 10;
+    ctb_QueueArray_enqueue(queue, &val);
+
+    TEST_ASSERT_FALSE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_INT(1, ctb_QueueArray_getLength(queue));
+}
+
+void test_ctb_QueueArray_enqueue_should_copy_value(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val = 42;
+    ctb_QueueArray_enqueue(queue, &val);
+
+    int * front = ctb_QueueArray_peek(queue);
+    TEST_ASSERT_NOT_NULL(front);
+    TEST_ASSERT_EQUAL_INT(42, *front);
+}
+
+void test_ctb_QueueArray_dequeue_should_return_and_remove_front(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val1 = 10;
+    int val2 = 20;
+    ctb_QueueArray_enqueue(queue, &val1);
+    ctb_QueueArray_enqueue(queue, &val2);
+
+    int * result = ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_EQUAL_INT(10, *result);
+    TEST_ASSERT_EQUAL_INT(1, ctb_QueueArray_getLength(queue));
+
+    result = ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_EQUAL_INT(20, *result);
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+}
+
+void test_ctb_QueueArray_dequeue_should_return_null_when_empty(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_peek_should_return_front_without_removing(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val = 99;
+    ctb_QueueArray_enqueue(queue, &val);
+
+    int * first = ctb_QueueArray_peek(queue);
+    TEST_ASSERT_NOT_NULL(first);
+    TEST_ASSERT_EQUAL_INT(99, *first);
+
+    // Peek again should return same value
+    int * second = ctb_QueueArray_peek(queue);
+    TEST_ASSERT_EQUAL_PTR(first, second);
+    TEST_ASSERT_EQUAL_INT(1, ctb_QueueArray_getLength(queue));
+}
+
+void test_ctb_QueueArray_peek_should_return_null_when_empty(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    TEST_ASSERT_NULL(ctb_QueueArray_peek(queue));
+}
+
+void test_ctb_QueueArray_clear_should_reset_queue(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val1 = 1;
+    int val2 = 2;
+    ctb_QueueArray_enqueue(queue, &val1);
+    ctb_QueueArray_enqueue(queue, &val2);
+
+    ctb_QueueArray_clear(queue);
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+    TEST_ASSERT_EQUAL_INT(0, ctb_QueueArray_getLength(queue));
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_enqueue_should_wrap_around(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 3)));
+
+    int val1 = 1;
+    int val2 = 2;
+    int val3 = 3;
+    ctb_QueueArray_enqueue(queue, &val1);
+    ctb_QueueArray_enqueue(queue, &val2);
+    ctb_QueueArray_enqueue(queue, &val3);
+
+    TEST_ASSERT_TRUE(ctb_QueueArray_getLength(queue) == 3);
+
+    // Dequeue 2 elements to advance head
+    ctb_QueueArray_dequeue(queue);
+    ctb_QueueArray_dequeue(queue);
+    TEST_ASSERT_EQUAL_INT(1, ctb_QueueArray_getLength(queue));
+
+    // Enqueue 2 more — these should wrap around
+    int val4 = 4;
+    int val5 = 5;
+    ctb_QueueArray_enqueue(queue, &val4);
+    ctb_QueueArray_enqueue(queue, &val5);
+
+    TEST_ASSERT_EQUAL_INT(3, ctb_QueueArray_getLength(queue));
+
+    // Verify FIFO order is preserved: 3, 4, 5
+    TEST_ASSERT_EQUAL_INT(3, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(4, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(5, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_TRUE(ctb_QueueArray_isEmpty(queue));
+}
+
+void test_ctb_QueueArray_enqueue_to_full_should_not_insert(void) {
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(int, 2)));
+
+    int val1 = 1;
+    int val2 = 2;
+    int val3 = 3;
+    ctb_QueueArray_enqueue(queue, &val1);
+    ctb_QueueArray_enqueue(queue, &val2);
+
+    // Queue is full; enqueue should do nothing
+    ctb_QueueArray_enqueue(queue, &val3);
+    TEST_ASSERT_EQUAL_INT(2, ctb_QueueArray_getLength(queue));
+
+    TEST_ASSERT_EQUAL_INT(1, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_EQUAL_INT(2, *(int *)ctb_QueueArray_dequeue(queue));
+    TEST_ASSERT_NULL(ctb_QueueArray_dequeue(queue));
+}
+
+void test_ctb_QueueArray_should_work_with_structs(void) {
+    typedef struct {
+        int id;
+        float value;
+    } test_Item_t;
+
+    ctb_QueueArray_t * queue = ctb_QueueArray_init(ctb_QueueArray(ctb_arr(test_Item_t, 3)));
+
+    test_Item_t item1 = { 42, 3.14f };
+    ctb_QueueArray_enqueue(queue, &item1);
+
+    test_Item_t * front = ctb_QueueArray_peek(queue);
+    TEST_ASSERT_NOT_NULL(front);
+    TEST_ASSERT_EQUAL_INT(42, front->id);
+}


### PR DESCRIPTION
Automated Agent Resolution for #8.

### Changes
- Implement `ctb_QueueArray` — an array-backed queue using a ring buffer pattern
- Users provide backing storage as a raw C array via the `ctb_QueueArray(arr)` init macro
- Operations: `init`, `enqueue`, `dequeue`, `peek`, `isEmpty`, `getLength`, `getCapacity`, `clear`
- The ring buffer wraps around when tail reaches capacity
- No heap allocation — fixed capacity determined by user-provided array

### Verification
- All 82 tests pass (including 11 new QueueArray tests)
- No regressions