### PR TITLE
feat(config): add ctb_config.h with user-overridable assertion macros

### DIFF
--- a/src/ctb.h
+++ b/src/ctb.h
@@ -3,7 +3,7 @@
  */
 #ifndef CTB_H
 #define CTB_H
-#include <assert.h>
+#include "ctb_config.h"
 #include <stddef.h>
 /**
  * @defgroup ctb ctb
@@ -81,7 +81,7 @@
     expression,           \
     identifier            \
 )                         \
-    typedef char identifier[(!!(expression)) * 2 - 1]
+    ctb_config_staticAssert(expression, identifier)
 
 /**
  * @brief Runtime assertion for design by contract validation
@@ -91,7 +91,7 @@
 #define ctb_assert( \
     expression      \
 )                   \
-    assert(expression)
+    ctb_config_assert(expression)
 
 /** @} */
 #endif // CTB_H

--- a/src/ctb_config.h
+++ b/src/ctb_config.h
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @brief User-configurable settings for the ctb library.
+ *
+ * This header provides safe default definitions for all ctb configurables.
+ * Users may place their own `ctb_config.h` earlier in the include path to
+ * override these defaults without modifying the library source.
+ */
+#ifndef CTB_CONFIG_H
+#define CTB_CONFIG_H
+
+#include <assert.h>
+
+/**
+ * @brief Runtime assertion macro.
+ *
+ * Defaults to the standard `assert()` macro. Users may define this before
+ * including this header to use a custom handler or no-op in constrained
+ * environments.
+ */
+#ifndef ctb_config_assert
+#define ctb_config_assert(expr) assert(expr)
+#endif
+
+/**
+ * @brief Compile-time (static) assertion macro.
+ *
+ * Defaults to the typedef-char trick which works in C99 without requiring
+ * `_Static_assert`. Users may define this before including this header to
+ * use a different mechanism (e.g., `_Static_assert` in C11).
+ *
+ * @param expr  Compile-time integer expression that must evaluate to non-zero.
+ * @param id    Unique identifier used to name the internal typedef.
+ */
+#ifndef ctb_config_staticAssert
+#define ctb_config_staticAssert(expr, id) \
+    typedef char id[(!!(expr)) * 2 - 1]
+#endif
+
+#endif /* CTB_CONFIG_H */


### PR DESCRIPTION
Automated Agent Resolution for #5.

### Changes
- Created `src/ctb_config.h` with safe defaults for `ctb_config_assert(expr)` and `ctb_config_staticAssert(expr, id)`
- Updated `src/ctb.h` to include `ctb_config.h` instead of `<assert.h>` directly
- Delegated `ctb_assert` → `ctb_config_assert` and `ctb_staticAssert` → `ctb_config_staticAssert`
- All 71 existing tests pass cleanly

### User override
Users can override defaults by placing their own `ctb_config.h` earlier in the include path. Each configurable is wrapped in `#ifndef` so user definitions take precedence.